### PR TITLE
Fix blish not rendering when y axis is 0

### DIFF
--- a/Estreya.BlishHUD.EventTable/Controls/EventArea.cs
+++ b/Estreya.BlishHUD.EventTable/Controls/EventArea.cs
@@ -53,7 +53,7 @@ public class EventArea : RenderTargetControl
     private readonly Func<SemVer.Version> _getVersion;
     private List<EventCategory> _allEvents = new List<EventCategory>();
 
-    private int _heightFromLastDraw = 0;
+    private int _heightFromLastDraw = 1; // Blish does not render controls at y 0 with 0 height
 
     private Event _lastActiveEvent;
 

--- a/Estreya.BlishHUD.EventTable/manifest.json
+++ b/Estreya.BlishHUD.EventTable/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Event Table",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "namespace": "estreya.bh.eventTable",
   "package": "Estreya.BlishHUD.EventTable.dll",
   "manifest_version": 1,


### PR DESCRIPTION
Fixes the problem that blish is not rendering the table on startup when the location y is set to 0